### PR TITLE
fix: remove wrangler.jsonc causing Pages to use wrong deploy method

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,0 @@
-{
-  "name": "jeffemmett-canvas",
-  "compatibility_date": "2025-11-16",
-  "assets": {
-    "directory": "./dist"
-  }
-}


### PR DESCRIPTION
Remove wrangler.jsonc from root - it was causing Cloudflare Pages to try deploying via Wrangler instead of using the standard Pages deployment.

Pages should build with npm run build and automatically deploy dist/ directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)